### PR TITLE
Feature flag for parallel clingo build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [features]
 dynamic_linking = ["clingo-sys/dynamic_linking"]
-parallel_build = ["clingo-sys/parallel-build"]
+parallel_build = ["clingo-sys/parallel_build"]
 
 # Provide derive(ToSymbol) macro.
 derive = ["clingo-derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/lib.rs"
 
 [features]
 dynamic_linking = ["clingo-sys/dynamic_linking"]
+parallel_build = ["clingo-sys/parallel-build"]
 
 # Provide derive(ToSymbol) macro.
 derive = ["clingo-derive"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ In your source write:
 
 The macro performs a conversion to snake case. This means the corresponing fact for `MyPoint{x:4,y:2}` is `my_point(4,2)`.
 
+## Parallel build
+
+It is possible to speed up the build of clingo, via parallel compilation. This is enabled by the feature `parallel_build`.
+
+```toml
+[dependencies]
+clingo = { version = "0.6.0", features = ["parallel_build"] }
+```
 
 ## Using `dynamic_linking`
 

--- a/clingo-sys/Cargo.toml
+++ b/clingo-sys/Cargo.toml
@@ -23,6 +23,6 @@ path = "lib.rs"
 libc = "0.2"
 
 [build-dependencies]
-cc = "1.0"
+cc = {version = "1.0", features = ["parallel"]}
 bindgen = "0.52"
 pkg-config = "0.3"

--- a/clingo-sys/Cargo.toml
+++ b/clingo-sys/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 
 [features]
 dynamic_linking = []
+parallel_build = ["cc/parallel"]
 
 [lib]
 name = "clingo_sys"
@@ -23,6 +24,6 @@ path = "lib.rs"
 libc = "0.2"
 
 [build-dependencies]
-cc = {version = "1.0", features = ["parallel"]}
+cc = "1.0"
 bindgen = "0.52"
 pkg-config = "0.3"


### PR DESCRIPTION
add feature "parallel" of crate `cc` as described in https://github.com/alexcrichton/cc-rs#parallel

I am fine with feature-guarding the parallel build, but I would like to make the case of making the parallel build the default option.