### PR TITLE
Make `FromSymbol` public.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6117,7 +6117,7 @@ impl<T: ToSymbol> ToSymbol for &T {
     }
 }
 
-trait FromSymbol: Sized {
+pub trait FromSymbol: Sized {
     fn from_symbol(symbol: Symbol) -> Result<Self, ClingoError>;
 }
 


### PR DESCRIPTION
It seems I forgot to make the `FromSymbol` trait public in my last PR.