### PR TITLE
Added associated type to `FromSymbol`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,10 @@ impl ClingoError {
             last: error_message(),
         }
     }
+
+    fn new_external(msg: &'static str) -> ClingoError {
+        ExternalError { msg: msg }.into()
+    }
 }
 #[derive(Error, Debug)]
 #[error("ExternalError: {msg}")]
@@ -6136,7 +6140,7 @@ impl FromSymbol for u8 {
         symbol
             .number()?
             .try_into()
-            .map_err(|_| ClingoError::new_internal("Could not convert to u8"))
+            .map_err(|_| ClingoError::new_external("Could not convert to u8"))
     }
 }
 impl FromSymbol for i8 {
@@ -6145,7 +6149,7 @@ impl FromSymbol for i8 {
         symbol
             .number()?
             .try_into()
-            .map_err(|_| ClingoError::new_internal("Could not convert to i8"))
+            .map_err(|_| ClingoError::new_external("Could not convert to i8"))
     }
 }
 impl FromSymbol for u16 {
@@ -6154,7 +6158,7 @@ impl FromSymbol for u16 {
         symbol
             .number()?
             .try_into()
-            .map_err(|_| ClingoError::new_internal("Could not convert to u16"))
+            .map_err(|_| ClingoError::new_external("Could not convert to u16"))
     }
 }
 impl FromSymbol for i16 {
@@ -6163,7 +6167,7 @@ impl FromSymbol for i16 {
         symbol
             .number()?
             .try_into()
-            .map_err(|_| ClingoError::new_internal("Could not convert to i16"))
+            .map_err(|_| ClingoError::new_external("Could not convert to i16"))
     }
 }
 impl FromSymbol for u32 {
@@ -6172,7 +6176,7 @@ impl FromSymbol for u32 {
         symbol
             .number()?
             .try_into()
-            .map_err(|_| ClingoError::new_internal("Could not convert to u32"))
+            .map_err(|_| ClingoError::new_external("Could not convert to u32"))
     }
 }
 impl FromSymbol for i32 {
@@ -6187,7 +6191,7 @@ impl FromSymbol for u64 {
         symbol
             .number()?
             .try_into()
-            .map_err(|_| ClingoError::new_internal("Could not convert to u64"))
+            .map_err(|_| ClingoError::new_external("Could not convert to u64"))
     }
 }
 impl FromSymbol for i64 {
@@ -6202,7 +6206,7 @@ impl FromSymbol for u128 {
         symbol
             .number()?
             .try_into()
-            .map_err(|_| ClingoError::new_internal("Could not convert to u128"))
+            .map_err(|_| ClingoError::new_external("Could not convert to u128"))
     }
 }
 impl FromSymbol for i128 {


### PR DESCRIPTION
This allows for more flexibility in composing `FromSymbol` instances.

<details>

<summary>an example is the (currently not published) combinator library we use in our project:</summary>

```rust
use clingo::{ClingoError, FromSymbol, Symbol};
use thiserror::Error;

#[derive(Error, Debug)]
pub enum Error {
    #[error("Expected predicate: {0}")]
    UnexpectedPredicate(&'static str),
    #[error("Clingo error: ")]
    ClingoError(#[from] ClingoError),
    #[error("Expected {expected} arguments, got {actual}")]
    WrongArgumentCount { expected: usize, actual: usize },
}

pub trait HasError: From<ClingoError> + From<Error> {
    fn has_error(&self) -> Option<&Error>;

    fn unexpected_predicate(&self) -> bool {
        if let Some(Error::UnexpectedPredicate(_)) = self.has_error() {
            true
        } else {
            false
        }
    }
}

impl HasError for Error {
    fn has_error(&self) -> Option<&Error> {
        Some(self)
    }
}

pub fn predicate<T: tuples::Tuples>(name: &str, symbol: Symbol) -> Result<T, Error> {
    let got_name = symbol.name()?;
    if got_name == name {
        arguments(symbol)
    } else {
        Err(Error::UnexpectedPredicate(got_name))
    }
}

pub fn fact(name: &str, symbol: Symbol) -> Result<(), Error> {
    let got_name = symbol.name()?;
    if got_name == name {
        Ok(()) // TODO: check that no arguments are given
    } else {
        Err(Error::UnexpectedPredicate(got_name))
    }
}

pub struct Alt(Symbol);

impl Alt {
    pub fn option<R, E, T: FromSymbol<Error = E>>(self, f: impl Fn(T) -> R) -> AltResult<R, E> {
        AltResult {
            symbol: self.0,
            result: T::from_symbol(self.0).map(f),
        }
    }
}

pub struct AltResult<R, E> {
    symbol: Symbol,
    result: Result<R, E>,
}

impl<R, E: HasError> AltResult<R, E> {
    pub fn option<T: FromSymbol<Error = E>>(self, f: impl Fn(T) -> R) -> AltResult<R, E> {
        let sym = self.symbol;
        AltResult {
            symbol: sym,
            result: self.result.or_else(|err| match err.has_error() {
                Some(Error::UnexpectedPredicate(_)) => T::from_symbol(sym).map(f),
                _ => Err(err),
            }),
        }
    }

    pub fn convert(self) -> Result<R, E> {
        self.result
    }
}

pub fn alt(symbol: Symbol) -> Alt {
    Alt(symbol)
}

mod tuples {
    use super::Symbol;
    pub trait Tuples: Sized {
        fn len() -> usize;
        fn from_slice(slice: &[Symbol]) -> Option<Self>;
    }

    impl Tuples for (Symbol,) {
        fn len() -> usize {
            1
        }
        fn from_slice(slice: &[Symbol]) -> Option<Self> {
            match slice {
                &[a] => Some((a,)),
                _ => None,
            }
        }
    }

    impl Tuples for (Symbol, Symbol) {
        fn len() -> usize {
            2
        }
        fn from_slice(slice: &[Symbol]) -> Option<Self> {
            match slice {
                &[a, b] => Some((a, b)),
                _ => None,
            }
        }
    }

    impl Tuples for (Symbol, Symbol, Symbol) {
        fn len() -> usize {
            3
        }
        fn from_slice(slice: &[Symbol]) -> Option<Self> {
            match slice {
                &[a, b, c] => Some((a, b, c)),
                _ => None,
            }
        }
    }
}

pub fn arguments<T: tuples::Tuples>(symbol: Symbol) -> Result<T, Error> {
    let args = symbol.arguments()?;
    T::from_slice(args.as_slice()).ok_or(
        Error::WrongArgumentCount {
            actual: args.len(),
            expected: T::len(),
        }
        .into(),
    )
}
```

</details>

This allows us to combine conversions much more easily. The combinator library will most likely change, but I think the `FromSymbol` definition is minimalistic and flexible enough to stay like this.

This PR also removes the tuple implementations for `FromSymbol`. These can be added again easily, but we have not thought it worth it since it slowed down or iterating process.

We're still thinking about whether the combinator lib should become its own library, or whether it shoud live as a module inside `clingo-rs`. Please let us know your thoughts :)