### PR TITLE
Fix typo in head literal variant

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -49,7 +49,7 @@ pub enum AggregateFunction {
 #[derive(Debug, Copy, Clone)]
 pub enum HeadLiteralType {
     Literal = clingo_ast_head_literal_type_clingo_ast_head_literal_type_literal as isize,
-    Disjuction = clingo_ast_head_literal_type_clingo_ast_head_literal_type_disjunction as isize,
+    Disjunction = clingo_ast_head_literal_type_clingo_ast_head_literal_type_disjunction as isize,
     Aggregate = clingo_ast_head_literal_type_clingo_ast_head_literal_type_aggregate as isize,
     HeadAggregate =
         clingo_ast_head_literal_type_clingo_ast_head_literal_type_head_aggregate as isize,


### PR DESCRIPTION
The `Disjunction` option of the `HeadLiteral` variant was incorrectly spelled (but only in these Rust bindings). This fixes the typo.

Unfortunately, this typo fix constitutes an API change (strictly speaking at least). An version bump may be necessary.

