### PR TITLE
Add support for comparing signs

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3,7 +3,7 @@ use crate::*;
 use std::fmt;
 use std::marker::PhantomData;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Sign {
     None = clingo_ast_sign_clingo_ast_sign_none as isize,
     Negation = clingo_ast_sign_clingo_ast_sign_negation as isize,


### PR DESCRIPTION
The `Sign` type isn’t derived from `PartialEq`. Consequently, conditions like

```rust
sign == clingo::ast::Sign::None
```

will result in compiler errors. This patch adds a `derive` directive from `PartialEq` to the `Sign` type to make this possible.