### PR TITLE
Properly represent head literal variant

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -47,13 +47,12 @@ pub enum AggregateFunction {
     Max = clingo_ast_aggregate_function_clingo_ast_aggregate_function_max as isize,
 }
 #[derive(Debug, Copy, Clone)]
-pub enum HeadLiteralType {
-    Literal = clingo_ast_head_literal_type_clingo_ast_head_literal_type_literal as isize,
-    Disjunction = clingo_ast_head_literal_type_clingo_ast_head_literal_type_disjunction as isize,
-    Aggregate = clingo_ast_head_literal_type_clingo_ast_head_literal_type_aggregate as isize,
-    HeadAggregate =
-        clingo_ast_head_literal_type_clingo_ast_head_literal_type_head_aggregate as isize,
-    TheoryAtom = clingo_ast_head_literal_type_clingo_ast_head_literal_type_theory_atom as isize,
+pub enum HeadLiteralType<'a> {
+    Literal(&'a Literal<'a>),
+    Disjunction(&'a Disjunction<'a>),
+    Aggregate(&'a Aggregate<'a>),
+    HeadAggregate(&'a HeadAggregate<'a>),
+    TheoryAtom(&'a TheoryAtom<'a>),
 }
 #[derive(Debug, Copy, Clone)]
 pub enum ScriptType {
@@ -327,34 +326,18 @@ pub struct HeadLiteral<'a> {
 }
 impl fmt::Debug for HeadLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.data.type_ as u32 {
-            clingo_ast_head_literal_type_clingo_ast_head_literal_type_literal => {
-                let literal = unsafe { self.data.__bindgen_anon_1.literal } as *const Literal;
-                let literal = unsafe { literal.as_ref() }.unwrap();
-                write!(f, "HeadLiteral {{ literal: {:?} }}", literal)
+        match self.head_literal_type() {
+            HeadLiteralType::Literal(lit) => write!(f, "HeadLiteral {{ literal: {:?} }}", lit),
+            HeadLiteralType::Disjunction(lit) => {
+                write!(f, "HeadLiteral {{ disjunction: {:?} }}", lit)
             }
-            clingo_ast_head_literal_type_clingo_ast_head_literal_type_disjunction => {
-                let dis = unsafe { self.data.__bindgen_anon_1.disjunction } as *const Disjunction;
-                let dis = unsafe { dis.as_ref() }.unwrap();
-                write!(f, "HeadLiteral {{ disjunction: {:?} }}", dis)
+            HeadLiteralType::Aggregate(agg) => write!(f, "HeadLiteral {{ aggregate: {:?} }}", agg),
+            HeadLiteralType::HeadAggregate(agg) => {
+                write!(f, "HeadLiteral {{ head_aggregate: {:?} }}", agg)
             }
-            clingo_ast_head_literal_type_clingo_ast_head_literal_type_aggregate => {
-                let agg = unsafe { self.data.__bindgen_anon_1.aggregate } as *const Aggregate;
-                let agg = unsafe { agg.as_ref() }.unwrap();
-                write!(f, "HeadLiteral {{ aggregate: {:?} }}", agg)
-            }
-            clingo_ast_head_literal_type_clingo_ast_head_literal_type_head_aggregate => {
-                let hagg =
-                    unsafe { self.data.__bindgen_anon_1.head_aggregate } as *const HeadAggregate;
-                let hagg = unsafe { hagg.as_ref() }.unwrap();
-                write!(f, "HeadLiteral {{ head_aggregate: {:?} }}", hagg)
-            }
-            clingo_ast_head_literal_type_clingo_ast_head_literal_type_theory_atom => {
-                let atom = unsafe { self.data.__bindgen_anon_1.theory_atom } as *const TheoryAtom;
-                let atom = unsafe { atom.as_ref() }.unwrap();
+            HeadLiteralType::TheoryAtom(atom) => {
                 write!(f, "HeadLiteral {{ theory_atom: {:?} }}", atom)
             }
-            x => panic!("Failed to match clingo_ast_head_literal_type: {}!", x),
         }
     }
 }
@@ -428,8 +411,46 @@ impl<'a> From<&'a TheoryAtom<'a>> for HeadLiteral<'a> {
     }
 }
 impl<'a> HeadLiteral<'a> {
-    pub fn print_lit(&self) -> Option<&clingo_sys::clingo_ast_literal> {
-        unsafe { self.data.__bindgen_anon_1.literal.as_ref() }
+    pub fn head_literal_type(&self) -> HeadLiteralType {
+        match self.data.type_ as u32 {
+            clingo_ast_head_literal_type_clingo_ast_head_literal_type_literal => {
+                HeadLiteralType::Literal(
+                    unsafe { (self.data.__bindgen_anon_1.literal as *const Literal).as_ref() }
+                        .unwrap(),
+                )
+            }
+            clingo_ast_head_literal_type_clingo_ast_head_literal_type_disjunction => {
+                HeadLiteralType::Disjunction(
+                    unsafe {
+                        (self.data.__bindgen_anon_1.disjunction as *const Disjunction).as_ref()
+                    }
+                    .unwrap(),
+                )
+            }
+            clingo_ast_head_literal_type_clingo_ast_head_literal_type_aggregate => {
+                HeadLiteralType::Aggregate(
+                    unsafe { (self.data.__bindgen_anon_1.aggregate as *const Aggregate).as_ref() }
+                        .unwrap(),
+                )
+            }
+            clingo_ast_head_literal_type_clingo_ast_head_literal_type_head_aggregate => {
+                HeadLiteralType::HeadAggregate(
+                    unsafe {
+                        (self.data.__bindgen_anon_1.head_aggregate as *const HeadAggregate).as_ref()
+                    }
+                    .unwrap(),
+                )
+            }
+            clingo_ast_head_literal_type_clingo_ast_head_literal_type_theory_atom => {
+                HeadLiteralType::TheoryAtom(
+                    unsafe {
+                        (self.data.__bindgen_anon_1.theory_atom as *const TheoryAtom).as_ref()
+                    }
+                    .unwrap(),
+                )
+            }
+            x => panic!("Failed to match clingo_ast_head_literal_type: {}.", x),
+        }
     }
 }
 


### PR DESCRIPTION
This adds a proper representation of the `HeadLiteral` variant options (such that their contents can be accessed) as well as an accessor method for the variant type. Previously, the head literal type was exposed as an opaque `enum` statement, which didn’t provide access to the actual type of the head literal, including nested elements.

Also, the `print_lit` method is removed because its functionality is superceded by the `Debug` trait implementations.