### PR TITLE
Fix optional fields

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2166,15 +2166,23 @@ impl fmt::Debug for Aggregate<'_> {
 impl<'a> Aggregate<'a> {
     pub fn new(
         elements: &'a [ConditionalLiteral<'a>],
-        left_guard: &'a AggregateGuard<'a>,
-        right_guard: &'a AggregateGuard<'a>,
+        left_guard: Option<&'a AggregateGuard<'a>>,
+        right_guard: Option<&'a AggregateGuard<'a>>,
     ) -> Aggregate<'a> {
+        let left_guard = match &left_guard {
+            Some(left_guard) => &left_guard.data,
+            None => std::ptr::null(),
+        };
+        let right_guard = match &right_guard {
+            Some(right_guard) => &right_guard.data,
+            None => std::ptr::null(),
+        };
         Aggregate {
             data: clingo_ast_aggregate {
                 elements: elements.as_ptr() as *const clingo_ast_conditional_literal_t,
                 size: elements.len(),
-                left_guard: &left_guard.data,
-                right_guard: &right_guard.data,
+                left_guard,
+                right_guard,
             },
             _lifetime: PhantomData,
         }
@@ -2187,19 +2195,21 @@ impl<'a> Aggregate<'a> {
             )
         }
     }
-    pub fn left_guard(&self) -> &'a AggregateGuard<'a> {
-        unsafe {
-            (self.data.left_guard as *const clingo_ast_aggregate_guard as *const AggregateGuard)
-                .as_ref()
+    pub fn left_guard(&self) -> Option<&'a AggregateGuard<'a>> {
+        let pointer =
+            self.data.left_guard as *const clingo_ast_aggregate_guard as *const AggregateGuard;
+        match pointer.is_null() {
+            true => None,
+            false => Some(unsafe { pointer.as_ref() }.unwrap()),
         }
-        .unwrap()
     }
-    pub fn right_guard(&self) -> &'a AggregateGuard<'a> {
-        unsafe {
-            (self.data.right_guard as *const clingo_ast_aggregate_guard as *const AggregateGuard)
-                .as_ref()
+    pub fn right_guard(&self) -> Option<&'a AggregateGuard<'a>> {
+        let pointer =
+            self.data.right_guard as *const clingo_ast_aggregate_guard as *const AggregateGuard;
+        match pointer.is_null() {
+            true => None,
+            false => Some(unsafe { pointer.as_ref() }.unwrap()),
         }
-        .unwrap()
     }
 }
 
@@ -2260,16 +2270,24 @@ impl<'a> BodyAggregate<'a> {
     pub fn new(
         function: AggregateFunction,
         elements: &'a [BodyAggregateElement<'a>],
-        left_guard: &'a AggregateGuard<'a>,
-        right_guard: &'a AggregateGuard<'a>,
+        left_guard: Option<&'a AggregateGuard<'a>>,
+        right_guard: Option<&'a AggregateGuard<'a>>,
     ) -> BodyAggregate<'a> {
+        let left_guard = match &left_guard {
+            Some(left_guard) => &left_guard.data,
+            None => std::ptr::null(),
+        };
+        let right_guard = match &right_guard {
+            Some(right_guard) => &right_guard.data,
+            None => std::ptr::null(),
+        };
         BodyAggregate {
             data: clingo_ast_body_aggregate {
                 function: function as i32,
                 elements: elements.as_ptr() as *const clingo_ast_body_aggregate_element_t,
                 size: elements.len(),
-                left_guard: &left_guard.data,
-                right_guard: &right_guard.data,
+                left_guard,
+                right_guard,
             },
             _lifetime: PhantomData,
         }
@@ -2302,19 +2320,21 @@ impl<'a> BodyAggregate<'a> {
             )
         }
     }
-    pub fn left_guard(&self) -> &'a AggregateGuard<'a> {
-        unsafe {
-            (self.data.left_guard as *const clingo_ast_aggregate_guard as *const AggregateGuard)
-                .as_ref()
+    pub fn left_guard(&self) -> Option<&'a AggregateGuard<'a>> {
+        let pointer =
+            self.data.left_guard as *const clingo_ast_aggregate_guard as *const AggregateGuard;
+        match pointer.is_null() {
+            true => None,
+            false => Some(unsafe { pointer.as_ref() }.unwrap()),
         }
-        .unwrap()
     }
-    pub fn right_guard(&self) -> &'a AggregateGuard<'a> {
-        unsafe {
-            (self.data.right_guard as *const clingo_ast_aggregate_guard as *const AggregateGuard)
-                .as_ref()
+    pub fn right_guard(&self) -> Option<&'a AggregateGuard<'a>> {
+        let pointer =
+            self.data.right_guard as *const clingo_ast_aggregate_guard as *const AggregateGuard;
+        match pointer.is_null() {
+            true => None,
+            false => Some(unsafe { pointer.as_ref() }.unwrap()),
         }
-        .unwrap()
     }
 }
 #[derive(Copy, Clone)]
@@ -2379,16 +2399,24 @@ impl<'a> HeadAggregate<'a> {
     pub fn new(
         function: AggregateFunction,
         elements: &'a [HeadAggregateElement<'a>],
-        left_guard: &'a AggregateGuard<'a>,
-        right_guard: &'a AggregateGuard<'a>,
+        left_guard: Option<&'a AggregateGuard<'a>>,
+        right_guard: Option<&'a AggregateGuard<'a>>,
     ) -> HeadAggregate<'a> {
+        let left_guard = match &left_guard {
+            Some(left_guard) => &left_guard.data,
+            None => std::ptr::null(),
+        };
+        let right_guard = match &right_guard {
+            Some(right_guard) => &right_guard.data,
+            None => std::ptr::null(),
+        };
         HeadAggregate {
             data: clingo_ast_head_aggregate {
                 function: function as i32,
                 elements: elements.as_ptr() as *const clingo_ast_head_aggregate_element_t,
                 size: elements.len(),
-                left_guard: &left_guard.data,
-                right_guard: &right_guard.data,
+                left_guard,
+                right_guard,
             },
             _lifetime: PhantomData,
         }
@@ -2421,19 +2449,21 @@ impl<'a> HeadAggregate<'a> {
             )
         }
     }
-    pub fn left_guard(&self) -> &'a AggregateGuard<'a> {
-        unsafe {
-            (self.data.left_guard as *const clingo_ast_aggregate_guard as *const AggregateGuard)
-                .as_ref()
+    pub fn left_guard(&self) -> Option<&'a AggregateGuard<'a>> {
+        let pointer =
+            self.data.left_guard as *const clingo_ast_aggregate_guard as *const AggregateGuard;
+        match pointer.is_null() {
+            true => None,
+            false => Some(unsafe { pointer.as_ref() }.unwrap()),
         }
-        .unwrap()
     }
-    pub fn right_guard(&self) -> &'a AggregateGuard<'a> {
-        unsafe {
-            (self.data.right_guard as *const clingo_ast_aggregate_guard as *const AggregateGuard)
-                .as_ref()
+    pub fn right_guard(&self) -> Option<&'a AggregateGuard<'a>> {
+        let pointer =
+            self.data.right_guard as *const clingo_ast_aggregate_guard as *const AggregateGuard;
+        match pointer.is_null() {
+            true => None,
+            false => Some(unsafe { pointer.as_ref() }.unwrap()),
         }
-        .unwrap()
     }
 }
 #[derive(Copy, Clone)]
@@ -2947,14 +2977,18 @@ impl<'a> TheoryAtom<'a> {
     pub fn new(
         term: Term<'a>,
         elements: &'a [TheoryAtomElement<'a>],
-        guard: &'a TheoryGuard<'a>,
+        guard: Option<&'a TheoryGuard<'a>>,
     ) -> TheoryAtom<'a> {
+        let guard = match &guard {
+            Some(guard) => &guard.data,
+            None => std::ptr::null(),
+        };
         TheoryAtom {
             data: clingo_ast_theory_atom {
                 term: term.data,
                 elements: elements.as_ptr() as *const clingo_ast_theory_atom_element_t,
                 size: elements.len(),
-                guard: &guard.data as *const clingo_ast_theory_guard_t,
+                guard,
             },
             _lifetime: PhantomData,
         }
@@ -2970,11 +3004,12 @@ impl<'a> TheoryAtom<'a> {
             )
         }
     }
-    pub fn guard(&self) -> &'a TheoryGuard<'a> {
-        unsafe {
-            (self.data.guard as *const clingo_ast_theory_guard as *const TheoryGuard).as_ref()
+    pub fn guard(&self) -> Option<&'a TheoryGuard<'a>> {
+        let pointer = self.data.guard as *const clingo_ast_theory_guard as *const TheoryGuard;
+        match pointer.is_null() {
+            true => None,
+            false => Some(unsafe { pointer.as_ref() }.unwrap()),
         }
-        .unwrap()
     }
 }
 #[derive(Debug, Copy, Clone)]
@@ -3184,10 +3219,14 @@ impl<'a> TheoryAtomDefinition<'a> {
         atom_type: TheoryAtomType,
         arity: u32,
         elements: &str,
-        guard: &'a TheoryGuardDefinition<'a>,
+        guard: Option<&'a TheoryGuardDefinition<'a>>,
     ) -> Result<TheoryAtomDefinition<'a>, ClingoError> {
         let name = internalize_string(name)?;
         let elements = internalize_string(elements)?;
+        let guard = match &guard {
+            Some(guard) => &guard.data,
+            None => std::ptr::null(),
+        };
         Ok(TheoryAtomDefinition {
             data: clingo_ast_theory_atom_definition_t {
                 location: Location::default(),
@@ -3195,7 +3234,7 @@ impl<'a> TheoryAtomDefinition<'a> {
                 name,
                 arity,
                 elements,
-                guard: &guard.data,
+                guard,
             },
             _lifetime: PhantomData,
         })
@@ -3239,13 +3278,13 @@ impl<'a> TheoryAtomDefinition<'a> {
             c_str.to_str()
         }
     }
-    pub fn guard(&self) -> &'a TheoryGuardDefinition<'a> {
-        unsafe {
-            (self.data.guard as *const clingo_ast_theory_guard_definition
-                as *const TheoryGuardDefinition)
-                .as_ref()
+    pub fn guard(&self) -> Option<&'a TheoryGuardDefinition<'a>> {
+        let pointer = self.data.guard as *const clingo_ast_theory_guard_definition
+            as *const TheoryGuardDefinition;
+        match pointer.is_null() {
+            false => None,
+            true => Some(unsafe { pointer.as_ref() }.unwrap()),
         }
-        .unwrap()
     }
 }
 #[derive(Copy, Clone)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -356,12 +356,17 @@ fn ast_head_literal_test() {
 
     let term3 = Term::from(sym);
     let guard = AggregateGuard::gt(term3);
-    let agg = Aggregate::new(&elements, &guard, &guard);
+    let agg = Aggregate::new(&elements, Some(&guard), Some(&guard));
 
     let tuple = vec![term1];
     let helem = HeadAggregateElement::new(&tuple, cond);
     let elements = vec![helem];
-    let hagg = HeadAggregate::new(ast::AggregateFunction::Count, &elements, &guard, &guard);
+    let hagg = HeadAggregate::new(
+        ast::AggregateFunction::Count,
+        &elements,
+        Some(&guard),
+        Some(&guard),
+    );
 
     let th_term = TheoryTerm::from(sym);
     let tuple = vec![th_term];
@@ -369,7 +374,7 @@ fn ast_head_literal_test() {
     let elements = vec![element];
     let operator_name = String::from("theory_operator");
     let guard = TheoryGuard::new(&operator_name, th_term).unwrap();
-    let tatom = TheoryAtom::new(term1, &elements, &guard);
+    let tatom = TheoryAtom::new(term1, &elements, Some(&guard));
 
     let hlit = ast::HeadLiteral::from(&lit);
     assert_eq!(
@@ -381,13 +386,13 @@ fn ast_head_literal_test() {
     assert_eq!(format!("{:?}",hlit), "HeadLiteral { disjunction: Disjunction { elements: [ConditionalLiteral { literal: Literal { sign: None symbol: Term { symbol: test } }, condition: [Literal { sign: None symbol: Term { symbol: test } }] }] } }");
 
     let hlit = ast::HeadLiteral::from(&agg);
-    assert_eq!(format!("{:?}",hlit), "HeadLiteral { aggregate: Aggregate { elements: [ConditionalLiteral { literal: Literal { sign: None symbol: Term { symbol: test } }, condition: [Literal { sign: None symbol: Term { symbol: test } }] }], left_guard: AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }, right_guard: AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } } } }");
+    assert_eq!(format!("{:?}",hlit), "HeadLiteral { aggregate: Aggregate { elements: [ConditionalLiteral { literal: Literal { sign: None symbol: Term { symbol: test } }, condition: [Literal { sign: None symbol: Term { symbol: test } }] }], left_guard: Some(AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }), right_guard: Some(AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }) } }");
 
     let hlit = ast::HeadLiteral::from(&hagg);
-    assert_eq!(format!("{:?}",hlit), "HeadLiteral { head_aggregate: HeadAggregate { function: Count elements: [HeadAggregateElement { tuple: [Term { symbol: test }], conditional_literal: ConditionalLiteral { literal: Literal { sign: None symbol: Term { symbol: test } }, condition: [Literal { sign: None symbol: Term { symbol: test } }] } }], left_guard: AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }, right_guard: AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } } } }");
+    assert_eq!(format!("{:?}",hlit), "HeadLiteral { head_aggregate: HeadAggregate { function: Count elements: [HeadAggregateElement { tuple: [Term { symbol: test }], conditional_literal: ConditionalLiteral { literal: Literal { sign: None symbol: Term { symbol: test } }, condition: [Literal { sign: None symbol: Term { symbol: test } }] } }], left_guard: Some(AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }), right_guard: Some(AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }) } }");
 
     let hlit = ast::HeadLiteral::from(&tatom);
-    assert_eq!(format!("{:?}",hlit), "HeadLiteral { theory_atom: TheoryAtom { term: Term { symbol: test } elements: [TheoryAtomElement { tuple: [TheoryTerm { symbol: test }] condition: [Literal { sign: None symbol: Term { symbol: test } }] }] guard: TheoryGuard { operator_name: \"theory_operator\" term: TheoryTerm { symbol: test } } } }");
+    assert_eq!(format!("{:?}",hlit), "HeadLiteral { theory_atom: TheoryAtom { term: Term { symbol: test } elements: [TheoryAtomElement { tuple: [TheoryTerm { symbol: test }] condition: [Literal { sign: None symbol: Term { symbol: test } }] }] guard: Some(TheoryGuard { operator_name: \"theory_operator\" term: TheoryTerm { symbol: test } }) } }");
 }
 #[test]
 fn ast_body_literal_test() {
@@ -402,12 +407,17 @@ fn ast_body_literal_test() {
 
     let term3 = Term::from(sym);
     let guard = AggregateGuard::gt(term3);
-    let agg = Aggregate::new(&elements, &guard, &guard);
+    let agg = Aggregate::new(&elements, Some(&guard), Some(&guard));
 
     let tuple = vec![term1];
     let element = BodyAggregateElement::new(&tuple, &condition);
     let elements = vec![element];
-    let bagg = BodyAggregate::new(AggregateFunction::Count, &elements, &guard, &guard);
+    let bagg = BodyAggregate::new(
+        AggregateFunction::Count,
+        &elements,
+        Some(&guard),
+        Some(&guard),
+    );
 
     let th_term = TheoryTerm::from(sym);
     let tuple = vec![th_term];
@@ -415,7 +425,7 @@ fn ast_body_literal_test() {
     let elements = vec![element];
     let operator_name = String::from("theory_operator");
     let guard = TheoryGuard::new(&operator_name, th_term).unwrap();
-    let tatom = TheoryAtom::new(term1, &elements, &guard);
+    let tatom = TheoryAtom::new(term1, &elements, Some(&guard));
 
     let tuple = vec![term1];
     let csp_prod_term1 = CspProductTerm::new(term1, &term2);
@@ -440,19 +450,19 @@ fn ast_body_literal_test() {
     let blit = ast::BodyLiteral::from_aggregate(Sign::None, &agg);
     assert_eq!(
         format!("{:?}", blit),
-        "BodyLiteral { sign: None aggregate: Aggregate { elements: [ConditionalLiteral { literal: Literal { sign: None symbol: Term { symbol: test } }, condition: [Literal { sign: None symbol: Term { symbol: test } }] }], left_guard: AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }, right_guard: AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } } } }"
+        "BodyLiteral { sign: None aggregate: Aggregate { elements: [ConditionalLiteral { literal: Literal { sign: None symbol: Term { symbol: test } }, condition: [Literal { sign: None symbol: Term { symbol: test } }] }], left_guard: Some(AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }), right_guard: Some(AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }) } }"
     );
 
     let blit = ast::BodyLiteral::from_body_aggregate(Sign::None, &bagg);
     assert_eq!(
         format!("{:?}", blit),
-        "BodyLiteral { sign: None body_aggregate: BodyAggregate { function: Count elements: [BodyAggregateElement { tuple: [Term { symbol: test }], condition: [Literal { sign: None symbol: Term { symbol: test } }] }], left_guard: AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }, right_guard: AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } } } }"
+        "BodyLiteral { sign: None body_aggregate: BodyAggregate { function: Count elements: [BodyAggregateElement { tuple: [Term { symbol: test }], condition: [Literal { sign: None symbol: Term { symbol: test } }] }], left_guard: Some(AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }), right_guard: Some(AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }) } }"
     );
 
     let blit = ast::BodyLiteral::from_theory_atom(Sign::None, &tatom);
     assert_eq!(
         format!("{:?}", blit),
-        "BodyLiteral { sign: None theory_atom: TheoryAtom { term: Term { symbol: test } elements: [TheoryAtomElement { tuple: [TheoryTerm { symbol: test }] condition: [Literal { sign: None symbol: Term { symbol: test } }] }] guard: TheoryGuard { operator_name: \"theory_operator\" term: TheoryTerm { symbol: test } } } }"
+        "BodyLiteral { sign: None theory_atom: TheoryAtom { term: Term { symbol: test } elements: [TheoryAtomElement { tuple: [TheoryTerm { symbol: test }] condition: [Literal { sign: None symbol: Term { symbol: test } }] }] guard: Some(TheoryGuard { operator_name: \"theory_operator\" term: TheoryTerm { symbol: test } }) } }"
     );
 
     let blit = ast::BodyLiteral::from_disjoint(Sign::None, &dis);
@@ -642,11 +652,11 @@ fn ast_rule_head_aggregate() {
     let elements = vec![cond];
     let left_guard = AggregateGuard::gt(term);
     let right_guard = AggregateGuard::lt(term);
-    let agg = Aggregate::new(&elements, &left_guard, &right_guard);
+    let agg = Aggregate::new(&elements, Some(&left_guard), Some(&right_guard));
     let hlit = HeadLiteral::from(&agg);
     let rule = Rule::new(hlit, &[]);
     let stm = rule.ast_statement();
-    test_statement(&stm, "Statement { rule: Rule { head: HeadLiteral { aggregate: Aggregate { elements: [ConditionalLiteral { literal: Literal { sign: None symbol: Term { symbol: test } }, condition: [Literal { sign: None symbol: Term { symbol: test } }] }], left_guard: AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }, right_guard: AggregateGuard { comparison: LessThan, term: Term { symbol: test } } } }, body: [] } }");
+    test_statement(&stm, "Statement { rule: Rule { head: HeadLiteral { aggregate: Aggregate { elements: [ConditionalLiteral { literal: Literal { sign: None symbol: Term { symbol: test } }, condition: [Literal { sign: None symbol: Term { symbol: test } }] }], left_guard: Some(AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }), right_guard: Some(AggregateGuard { comparison: LessThan, term: Term { symbol: test } }) } }, body: [] } }");
 }
 #[test]
 fn ast_rule_head_head_aggregate() {
@@ -659,11 +669,16 @@ fn ast_rule_head_head_aggregate() {
     let helem = HeadAggregateElement::new(&tuple, cond);
     let elements = vec![helem];
     let guard = AggregateGuard::gt(term);
-    let hagg = HeadAggregate::new(AggregateFunction::Count, &elements, &guard, &guard);
+    let hagg = HeadAggregate::new(
+        AggregateFunction::Count,
+        &elements,
+        Some(&guard),
+        Some(&guard),
+    );
     let hlit = HeadLiteral::from(&hagg);
     let rule = Rule::new(hlit, &[]);
     let stm = rule.ast_statement();
-    test_statement(&stm, "Statement { rule: Rule { head: HeadLiteral { head_aggregate: HeadAggregate { function: Count elements: [HeadAggregateElement { tuple: [Term { symbol: test }], conditional_literal: ConditionalLiteral { literal: Literal { sign: None symbol: Term { symbol: test } }, condition: [Literal { sign: None symbol: Term { symbol: test } }] } }], left_guard: AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }, right_guard: AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } } } }, body: [] } }");
+    test_statement(&stm, "Statement { rule: Rule { head: HeadLiteral { head_aggregate: HeadAggregate { function: Count elements: [HeadAggregateElement { tuple: [Term { symbol: test }], conditional_literal: ConditionalLiteral { literal: Literal { sign: None symbol: Term { symbol: test } }, condition: [Literal { sign: None symbol: Term { symbol: test } }] } }], left_guard: Some(AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }), right_guard: Some(AggregateGuard { comparison: GreaterThan, term: Term { symbol: test } }) } }, body: [] } }");
 }
 #[test]
 fn ast_rule() {

--- a/tests/ui/ast_aggregate.rs
+++ b/tests/ui/ast_aggregate.rs
@@ -11,7 +11,7 @@ fn main() {
     let cond = ast::ConditionalLiteral::new(&lit, &condition);
     let elements = vec![cond];
     let mut guard = ast::AggregateGuard::gt(term3);
-    let agg = ast::Aggregate::new( &elements, &guard, &guard);
+    let agg = ast::Aggregate::new( &elements, Some(&guard), Some(&guard));
     
     guard =  ast::AggregateGuard::gt(term1);
     lit = ast::Literal::from_term(ast::Sign::None, &term1);

--- a/tests/ui/ast_aggregate.stderr
+++ b/tests/ui/ast_aggregate.stderr
@@ -1,8 +1,8 @@
 error[E0506]: cannot assign to `guard` because it is borrowed
   --> $DIR/ast_aggregate.rs:16:5
    |
-14 |     let agg = ast::Aggregate::new( &elements, &guard, &guard);
-   |                                               ------ borrow of `guard` occurs here
+14 |     let agg = ast::Aggregate::new( &elements, Some(&guard), Some(&guard));
+   |                                                    ------ borrow of `guard` occurs here
 15 |     
 16 |     guard =  ast::AggregateGuard::gt(term1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `guard` occurs here
@@ -24,13 +24,10 @@ error[E0506]: cannot assign to `lit` because it is borrowed
 error[E0505]: cannot move out of `elements` because it is borrowed
   --> $DIR/ast_aggregate.rs:18:10
    |
-14 |     let agg = ast::Aggregate::new( &elements, &guard, &guard);
+14 |     let agg = ast::Aggregate::new( &elements, Some(&guard), Some(&guard));
    |                                    --------- borrow of `elements` occurs here
 ...
 18 |     drop(elements);
    |          ^^^^^^^^ move out of `elements` occurs here
 19 |     let _end = (guard, lit, agg);
    |                             --- borrow later used here
-
-Some errors have detailed explanations: E0505, E0506.
-For more information about an error, try `rustc --explain E0505`.

--- a/tests/ui/ast_head_aggregate.rs
+++ b/tests/ui/ast_head_aggregate.rs
@@ -5,7 +5,12 @@ fn main() {
     let term = ast::Term::from(sym);
     let mut guard = ast::AggregateGuard::gt(term);
     let elements = vec![];
-    let hagg = ast::HeadAggregate::new(ast::AggregateFunction::Count, &elements, &guard, &guard);
+    let hagg = ast::HeadAggregate::new(
+        ast::AggregateFunction::Count,
+        &elements,
+        Some(&guard),
+        Some(&guard),
+    );
     guard =  ast::AggregateGuard::gt(term);
     drop(elements);
     let _end = (guard, hagg);

--- a/tests/ui/ast_head_aggregate.stderr
+++ b/tests/ui/ast_head_aggregate.stderr
@@ -1,24 +1,22 @@
 error[E0506]: cannot assign to `guard` because it is borrowed
-  --> $DIR/ast_head_aggregate.rs:9:5
+  --> $DIR/ast_head_aggregate.rs:14:5
    |
-8  |     let hagg = ast::HeadAggregate::new(ast::AggregateFunction::Count, &elements, &guard, &guard);
-   |                                                                                  ------ borrow of `guard` occurs here
-9  |     guard =  ast::AggregateGuard::gt(term);
+11 |         Some(&guard),
+   |              ------ borrow of `guard` occurs here
+...
+14 |     guard =  ast::AggregateGuard::gt(term);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `guard` occurs here
-10 |     drop(elements);
-11 |     let _end = (guard, hagg);
+15 |     drop(elements);
+16 |     let _end = (guard, hagg);
    |                        ---- borrow later used here
 
 error[E0505]: cannot move out of `elements` because it is borrowed
-  --> $DIR/ast_head_aggregate.rs:10:10
+  --> $DIR/ast_head_aggregate.rs:15:10
    |
-8  |     let hagg = ast::HeadAggregate::new(ast::AggregateFunction::Count, &elements, &guard, &guard);
-   |                                                                       --------- borrow of `elements` occurs here
-9  |     guard =  ast::AggregateGuard::gt(term);
-10 |     drop(elements);
+10 |         &elements,
+   |         --------- borrow of `elements` occurs here
+...
+15 |     drop(elements);
    |          ^^^^^^^^ move out of `elements` occurs here
-11 |     let _end = (guard, hagg);
+16 |     let _end = (guard, hagg);
    |                        ---- borrow later used here
-
-Some errors have detailed explanations: E0505, E0506.
-For more information about an error, try `rustc --explain E0505`.


### PR DESCRIPTION
These fields are optional in the Clingo API ([this can be verified in Clingo’s C++ bindings](https://github.com/potassco/clingo/blob/v5.4.0/libclingo/clingo.hh#L1408)), that is, they may be set to null pointers to indicate that these values aren’t set. However, they were exposed as required fields in these Rust bindings.

This patch turns these fields optional by adjusting the constructor and accessor methods to accept and return optional values. Some of the tests are rewritten to account for optional values.

The following fields are turned optional by this patch:

- `Aggregate`: `left_guard` and `right_guard`
- `BodyAggregate`: `left_guard` and `right_guard`
- `HeadAggregate`: `left_guard` and `right_guard`
- `TheoryAtom`: `guard`
- `TheoryAtomDefinition`: `guard`