### PR TITLE
More idiomatic timeout in `SolveHandle::wait`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ use std::os::raw::c_void;
 use std::ptr::NonNull;
 use std::str::Utf8Error;
 use thiserror::Error;
+use std::time::Duration;
 
 /// Functions and data structures to work with program ASTs.
 pub mod ast;
@@ -4788,9 +4789,10 @@ impl<'a> SolveHandle<'a> {
     /// # Arguments
     ///
     /// * `timeout` - the maximum time to wait
-    pub fn wait(&mut self, timeout: f64) -> bool {
+    pub fn wait(&mut self, timeout: Duration) -> bool {
         let mut result = false;
-        unsafe { clingo_solve_handle_wait(self.theref, timeout, &mut result) }
+        let timeout_secs = timeout.as_secs_f64();
+        unsafe { clingo_solve_handle_wait(self.theref, timeout_secs, &mut result) }
         result
     }
 


### PR DESCRIPTION
Only the simple api change from `timeout: f64` to `timeout: Duration`.


`cargo test` seemed to be happy